### PR TITLE
Add success callback

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -13,7 +13,7 @@ const xml2js = require('xml2js');
  */
 class UMDCASStrategy extends Strategy {
 
-    constructor(options) {
+    constructor(options, onSuccess) {
         super();
         this.name = 'umd-cas';
 
@@ -21,6 +21,7 @@ class UMDCASStrategy extends Strategy {
         if (!options.callbackURL) { throw new TypeError('UMDCASStrategy needs a callback url') }
 
         this._callbackURL = options.callbackURL;
+        this._onSuccess = onSuccess;
     }
 
     authenticate(req, options) {
@@ -34,9 +35,15 @@ class UMDCASStrategy extends Strategy {
                 .then(result => {
                     
                     if('cas:authenticationSuccess' in result['cas:serviceResponse']) {
-                        this.success({
+                        const user = {
                             uid: result['cas:serviceResponse']['cas:authenticationSuccess'][0]['cas:attributes'][0]['cas:uid'][0],
-                        });
+                        };
+
+                        if (this._onSuccess) {
+                            this._onSuccess(user, this.success);
+                        } else {
+                            this.success(user);
+                        }
                     } else {
                         this.fail('Authentication failed', 400);
                     }

--- a/test/strategy.auth.test.js
+++ b/test/strategy.auth.test.js
@@ -125,4 +125,38 @@ describe('Strategy authentication', () => {
             expect(error).to.equal('Authentication failed');
         });
     });
+
+    describe('Receiving request with valid ticket and onSuccess callback', () => {
+        
+        const strategy = new Strategy({ callbackURL: '/example/callback' }, (profile, done) => {
+            done({
+                name: profile.uid
+            });
+        });
+        let user, info, error;
+
+        before(done => {
+            chai.passport.use(strategy)
+                .success((u, i) => {
+                    user = u;
+                    info = i;
+                    done();
+                })
+                .fail(err => {
+                    error = err;
+                    done();
+                })
+                .req(req => {
+                    // Mock request
+                    req.query = { ticket: 'validTicket' };
+                    req.protocol = 'http';
+                    req.get = param => param == 'host' ? 'localhost' : null;
+                })
+                .authenticate();
+        });
+
+        it('successfully authenticates', () => {
+            expect(user).to.have.property('name', 'studentUID')
+        });
+    });
 });

--- a/test/strategy.create.test.js
+++ b/test/strategy.create.test.js
@@ -42,4 +42,19 @@ describe('Strategy creation', () => {
         });
     });
 
+    describe('Create valid strategy with onSuccess callback', () => {
+
+        function onSuccess(profile, done) {
+            done({
+                name: profile.uid
+            });
+        }
+
+        const strategy = new Strategy({ callbackURL: '/example/callback' }, onSuccess);
+
+        it('has callback function', () => {
+            expect(strategy._onSuccess).to.equal(onSuccess);
+        });
+    });
+
 });


### PR DESCRIPTION
First off thanks for making this package!

I added an optional success callback to alter the user object or save it to a database before passport adds it to the session. Useful for using multiple login strategies with one user model.

Usage example:
![image](https://user-images.githubusercontent.com/37424733/90945586-b74c2400-e3f3-11ea-981d-4e82339405a2.png)



